### PR TITLE
Rename repository to mlb-api-mcp and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,96 @@
+# MLB API MCP Server
+
+A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that provides comprehensive access to MLB statistics and baseball data through a FastAPI-based interface.
+
+## Overview
+
+This MCP server acts as a bridge between AI applications and MLB data sources, enabling seamless integration of baseball statistics, game information, player data, and more into AI workflows and applications.
+
+## Features
+
+### MLB Data Access
+- **Current standings** for all MLB teams
+- **Game schedules** and results 
+- **Player statistics** and information
+- **Team rosters** and details
+- **Live scores** and game data
+- **Historical statistics** and records
+
+### API Endpoints
+- RESTful API interface via FastAPI
+- Comprehensive MLB Stats API integration
+- Real-time and historical data access
+- Structured JSON responses
+
+### MCP Integration
+- Compatible with MCP-enabled AI applications
+- Tool-based interaction model
+- Automatic API documentation generation
+- Schema validation and type safety
+
+## Installation
+
+1. Clone the repository:
+```bash
+git clone https://github.com/guillochon/mlb-api-mcp.git
+cd mlb-api-mcp
+```
+
+2. Install dependencies:
+```bash
+pip install -e .
+```
+
+## Usage
+
+### Starting the Server
+
+Run the MCP server locally:
+```bash
+python main.py
+```
+
+The server will start on `http://localhost:8000` with interactive API documentation available at `http://localhost:8000/docs`.
+
+### MCP Client Integration
+
+This server can be integrated into any MCP-compatible application. The server provides tools for:
+- Retrieving team standings
+- Getting game schedules
+- Accessing player statistics
+- Fetching team information
+- And much more...
+
+## API Documentation
+
+Once the server is running, visit `http://localhost:8000/docs` for comprehensive API documentation including:
+- Available endpoints
+- Request/response schemas
+- Interactive testing interface
+- Example usage
+
+## Dependencies
+
+- **FastAPI**: Modern web framework for building APIs
+- **fastapi-mcp**: MCP integration for FastAPI
+- **python-mlb-statsapi**: Official MLB Statistics API wrapper
+
+## Development
+
+This project uses:
+- Python 3.10+
+- FastAPI for the web framework
+- Hatchling for build management
+- MLB Stats API for data access
+
+## Repository Rename
+
+This repository was recently renamed from `mcp` to `mlb-api-mcp` to better reflect its purpose as an MLB-focused MCP server. See [issue #1](../../issues/1) for the full discussion.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit issues or pull requests.
+
+## License
+
+This project is open source. Please check the license file for details.

--- a/main.py
+++ b/main.py
@@ -4,8 +4,8 @@ from mlb_api import router as mlb_router
 from generic_api import router as generic_router
 
 app = FastAPI(
-    title="MCP API Gateway",
-    description="API Gateway for various services including MLB statistics and more",
+    title="MLB API MCP Server",
+    description="Model Context Protocol server providing MLB statistics and baseball data APIs",
     version="0.1.0"
 )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "mcp-project"
+name = "mlb-api-mcp"
 version = "0.1.0"
-description = "MCP Project"
+description = "MLB API MCP Server - Model Context Protocol server for MLB statistics and baseball data"
 requires-python = ">=3.10"
 dependencies = [
     "fastapi-mcp>=0.3.4",


### PR DESCRIPTION
## Summary

This PR prepares the repository for renaming to `mlb-api-mcp` by updating all internal references and documentation to reflect the new, more descriptive name.

## Changes Made

### 📝 Documentation
- **Added comprehensive README.md** with project overview, installation instructions, usage examples, and API documentation
- **Updated project metadata** in `pyproject.toml` to reflect the new name and purpose
- **Enhanced API descriptions** in `main.py` for better clarity

### 🔧 Technical Updates
- Changed project name from `mcp-project` to `mlb-api-mcp` in `pyproject.toml`
- Updated FastAPI title from "MCP API Gateway" to "MLB API MCP Server"
- Improved project description to clearly indicate MLB/baseball focus
- Added proper project documentation structure

### 🎯 Benefits
- **Better discoverability**: The name clearly indicates this is MLB-related
- **Professional presentation**: Comprehensive documentation for users and contributors
- **Clear purpose**: Eliminates confusion about what this repository does
- **SEO improvement**: More specific naming helps with search and discovery

## Related Issue

Addresses #1 - Repository rename discussion

## Next Steps

After this PR is merged, the actual repository name change will need to be done through GitHub's repository settings:
1. Go to Settings → General → Repository name
2. Change from `mcp` to `mlb-api-mcp`
3. Update any local clones and external references

## Testing

- ✅ All file changes are documentation/metadata only
- ✅ No breaking changes to existing functionality
- ✅ New README provides clear setup and usage instructions